### PR TITLE
Fix regex pattern that parses extractedValues based on sseifert-akamai's

### DIFF
--- a/example/akamai.jsonnet
+++ b/example/akamai.jsonnet
@@ -13,6 +13,9 @@ test.suite {
         query: [
           { key: 'x-akamai-session-info', value: 'name=RO_ENABLED; value=false' },
           { key: 'x-akamai-session-info', value: 'name=AKA_PM_CACHEABLE_OBJECT; value=true' },
+          { key: 'x-akamai-session-info', value: 'name=PMUSER_EXTRACTED_1; value=key1=value1; key2=value2; full_location_id=Name1; separator=%s' % test.utils.escapeString('%3d') },
+          { key: 'x-akamai-session-info', value: 'name=PMUSER_EXTRACTED_2; value=key3=value3; key4=value4; full_location_id=Name2' },
+          
         ],
       }) + test.pragma.getExtractedValues,
       tests: [
@@ -20,6 +23,8 @@ test.suite {
         test.assertExtractedValueExists('test.assertExtractedValueExists', 'AKA_PM_CACHEABLE_OBJECT'),
         test.assertExtractedValueDoesNotExist('test.assertExtractedValueDoesNotExist', 'FAKE_VARIABLE'),
         test.assertExtractedValueEquals('test.assertExtractedValueEquals', 'RO_ENABLED', 'false'),
+        test.assertExtractedValueEquals('test.assertExtractedValueEquals with full_location_id', 'PMUSER_EXTRACTED_1', 'key1=value1; key2=value2'),
+        test.assertExtractedValueEquals('test.assertExtractedValueEquals with full_location_id and separator', 'PMUSER_EXTRACTED_2', 'key3=value3; key4=value4'),
         test.assertExtractedValueDoesNotEqual('test.assertExtractedValueDoesNotEqual', 'RO_ENABLED', 'true'),
         test.assertExtractedValueMatches('test.assertExtractedValueMatches', 'RO_ENABLED', 'f.lse'),
         test.assertExtractedValueDoesNotMatch('test.assertExtractedValueDoesNotMatch', 'RO_ENABLED', 'tr.e'),

--- a/src/js/akamai.js
+++ b/src/js/akamai.js
@@ -203,7 +203,7 @@ akamai = {
    * as an object.
    */
   extractedValues(response) {
-    let pat = /^name=([^;]*); value=([^;]*).*$/;
+    let pat = /^name=([^\s]*); value=(.*?)(?:; full_location_id=[^;]*(?:; separator=[^;]*)?)?$/;
     return getResponseHeaderValues(response, "x-akamai-session-info")
       .reduce(function (vars, value) {
         if (pat.test(value)) {


### PR DESCRIPTION
This is based on @sseifert-akamai 's [pr](https://github.com/akamai-contrib/postman-jsonnet/pull/7)

Test result:
[Postman Jsonnet-2024-07-23-10-04-24-298-0.zip](https://github.com/user-attachments/files/16347235/Postman.Jsonnet-2024-07-23-10-04-24-298-0.zip)
